### PR TITLE
docs: add logger round tripper documentation

### DIFF
--- a/pkg/httpx/logger/doc.go
+++ b/pkg/httpx/logger/doc.go
@@ -1,0 +1,5 @@
+// Package logger provides middleware for logging HTTP client requests and
+// responses. It exposes a Logger interface and a round tripper factory that can
+// be composed with other middlewares to trace requests, responses and elapsed
+// time. Hooks allow transforming or redacting bodies before they are logged.
+package logger

--- a/pkg/httpx/logger/example_logger_round_tripper_test.go
+++ b/pkg/httpx/logger/example_logger_round_tripper_test.go
@@ -1,0 +1,33 @@
+package logger_test
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/jeanmolossi/MaiGo/pkg/httpx"
+	"github.com/jeanmolossi/MaiGo/pkg/httpx/logger"
+)
+
+// ExampleLoggerRoundTripper demonstrates how to chain the logging round tripper
+// with a transport. It logs request/response metadata and returns the mocked
+// response from the builder.
+func ExampleLoggerRoundTripper() {
+	rt := httpx.Compose(
+		httpx.NewRoundTripMockBuilder().
+			AddOutcome(httpx.NewResp(200, `{"pong":true}`), nil).
+			Build(),
+		logger.LoggerRoundTripper(logger.LoggerHooks{
+			Logger:   logger.NewNoop(),
+			LogStart: true,
+			LogEnd:   true,
+		}),
+	)
+
+	req, _ := http.NewRequestWithContext(context.Background(), http.MethodPost, "http://foo.bar", bytes.NewBufferString(`{"ping":true}`))
+	resp, _ := rt.RoundTrip(req)
+	fmt.Println(resp.StatusCode)
+	// Output:
+	// 200
+}

--- a/pkg/httpx/logger/logger.go
+++ b/pkg/httpx/logger/logger.go
@@ -6,8 +6,12 @@ import (
 	"os"
 )
 
+// Logger abstracts the logging backend used by the round tripper. Implementations
+// must be safe for concurrent use.
 type Logger interface {
+	// Info writes an informational log message with optional attributes.
 	Info(ctx context.Context, msg string, args ...any)
+	// Error writes an error log message with optional attributes.
 	Error(ctx context.Context, err error, msg string, args ...any)
 }
 
@@ -19,16 +23,17 @@ var (
 
 type noopLogger struct{}
 
+// NewNoop returns a Logger that discards all logs.
 func NewNoop() *noopLogger {
 	return &noopLogger{}
 }
 
-// Error implements Logger.
+// Error implements Logger but performs no operation.
 func (n *noopLogger) Error(ctx context.Context, err error, msg string, args ...any) {
 	// noop
 }
 
-// Info implements Logger.
+// Info implements Logger but performs no operation.
 func (n *noopLogger) Info(ctx context.Context, msg string, args ...any) {
 	// noop
 }
@@ -37,6 +42,7 @@ type jsonLogger struct {
 	log *slog.Logger
 }
 
+// NewJSON creates a Logger that emits structured JSON logs using slog.
 func NewJSON() *jsonLogger {
 	return &jsonLogger{
 		log: slog.New(
@@ -45,12 +51,12 @@ func NewJSON() *jsonLogger {
 	}
 }
 
-// Error implements Logger.
+// Error implements Logger by logging the provided error in JSON format.
 func (j *jsonLogger) Error(ctx context.Context, err error, msg string, args ...any) {
 	j.log.ErrorContext(ctx, msg, append([]any{"error", err}, args...)...)
 }
 
-// Info implements Logger.
+// Info implements Logger by logging the message in JSON format.
 func (j *jsonLogger) Info(ctx context.Context, msg string, args ...any) {
 	j.log.InfoContext(ctx, msg, args...)
 }
@@ -59,16 +65,17 @@ type consoleLogger struct {
 	log *slog.Logger
 }
 
-// Error implements Logger.
+// Error implements Logger by logging the provided error in text format.
 func (c *consoleLogger) Error(ctx context.Context, err error, msg string, args ...any) {
 	c.log.ErrorContext(ctx, msg, append([]any{"error", err}, args...)...)
 }
 
-// Info implements Logger.
+// Info implements Logger by logging the message in text format.
 func (c *consoleLogger) Info(ctx context.Context, msg string, args ...any) {
 	c.log.InfoContext(ctx, msg, args...)
 }
 
+// NewConsole creates a Logger that writes human-readable text logs to stdout.
 func NewConsole() *consoleLogger {
 	return &consoleLogger{
 		log: slog.New(


### PR DESCRIPTION
## Summary
- add package level docs for logger round tripper
- document logger interfaces and hooks
- include usage example for LoggerRoundTripper

## Testing
- `make test`
- `go test -bench . ./...`
- `golangci-lint run ./...`


------
https://chatgpt.com/codex/tasks/task_e_6898eb7c1428832291cb7230f8af6906