### PR TITLE
feat: add concurrency limit to async group

### DIFF
--- a/examples/request_group/main.go
+++ b/examples/request_group/main.go
@@ -21,7 +21,7 @@ func main() {
 
 	start := time.Now()
 
-	group, err := async.All(
+	group, err := async.All(0,
 		client.GET("/users"),
 		client.GET("/resources"),
 	)


### PR DESCRIPTION
## Summary
- add optional concurrency limit to `async.All`
- use buffered channel as semaphore to restrict goroutines
- update request group example for new API

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68a5360f84d083228a86899f4c9c6b3f