### PR TITLE
feat: make logger body size configurable

### DIFF
--- a/pkg/httpx/logger/round_tripper_test.go
+++ b/pkg/httpx/logger/round_tripper_test.go
@@ -186,9 +186,10 @@ func TestLoggerRoundTripper_TruncatesRequestBodyAndLogsSize(t *testing.T) {
 
 	// Transformers who NOT delete body, else you log empty.
 	hooks := logger.LoggerHooks{
-		LogStart:      true,
-		LogEnd:        true,
-		SupressErrors: true,
+		LogStart:       true,
+		LogEnd:         true,
+		SupressErrors:  true,
+		MaxLogBodySize: maxLogBodySize,
 		ReqBodyTransformerFn: func(ctx context.Context) func([]byte) []byte {
 			return func(b []byte) []byte { read = len(b); return b }
 		},


### PR DESCRIPTION
## Summary
- allow configuring max logged body size via LoggerHooks
- use configured size when reading request and response bodies
- update truncation test to set max log body size

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68a5361386a08322b98ad2b3b1884f2b

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Novidades
  - Adicionada configuração por instância para limitar o tamanho do corpo registrado em logs, permitindo ajustar o truncamento conforme a necessidade. Valor padrão aplicado automaticamente (64 KiB) quando não definido.
- Documentação
  - Atualizações explicando o comportamento padrão e como configurar o limite de tamanho do corpo nos logs.
- Testes
  - Cobertura adicionada para validar o truncamento do corpo em logs de requisições e respostas, garantindo que o processamento completo ocorra enquanto o registro é limitado ao tamanho configurado.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->