### PR TITLE
fix: correct range error message

### DIFF
--- a/async/async.go
+++ b/async/async.go
@@ -112,7 +112,7 @@ func (g *Group) Wait() {
 func (g *Group) Result(i int) (contracts.Response, error) {
 	length := len(g.results)
 	if i > length-1 {
-		return nil, fmt.Errorf("index %d out ot range [0-%d]", i, length-1)
+		return nil, fmt.Errorf("index %d out of range [0-%d]", i, length-1)
 	}
 
 	if i < 0 {

--- a/async/async_test.go
+++ b/async/async_test.go
@@ -61,3 +61,17 @@ func TestAllConcurrencyLimit(t *testing.T) {
 		})
 	}
 }
+
+func TestGroupResultIndexOutOfRange(t *testing.T) {
+	g := &Group{results: make([]result, 1)}
+
+	_, err := g.Result(1)
+	if err == nil {
+		t.Fatalf("expected error, got nil")
+	}
+
+	expected := fmt.Sprintf("index %d out of range [0-%d]", 1, 0)
+	if err.Error() != expected {
+		t.Fatalf("expected error %q got %q", expected, err.Error())
+	}
+}


### PR DESCRIPTION
## Summary
- fix typo in async group result out-of-range error
- add test for error message on invalid index

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68a55900f3488322a9abfd1dc1b3c1be