### PR TITLE
refactor: add generic AsXML method

### DIFF
--- a/pkg/maigo/contracts/response.go
+++ b/pkg/maigo/contracts/response.go
@@ -38,8 +38,8 @@ type ResponseFluentBody interface {
 	AsBytes() ([]byte, error)
 	// AsString reads the body as a string.
 	AsString() (string, error)
-        // AsJSON decodes the body as JSON into v.
-        AsJSON(v any) error
+	// AsJSON decodes the body as JSON into v.
+	AsJSON(v any) error
 }
 
 // ResponseFluentCookie provides access to cookies returned by the server.

--- a/pkg/maigo/contracts/response.go
+++ b/pkg/maigo/contracts/response.go
@@ -38,10 +38,8 @@ type ResponseFluentBody interface {
 	AsBytes() ([]byte, error)
 	// AsString reads the body as a string.
 	AsString() (string, error)
-	// AsJSON decodes the body as JSON into v.
-	AsJSON(v any) error
-	// AsXML decodes the body as XML into v.
-	AsXML(v any) error
+        // AsJSON decodes the body as JSON into v.
+        AsJSON(v any) error
 }
 
 // ResponseFluentCookie provides access to cookies returned by the server.

--- a/pkg/maigo/response_body.go
+++ b/pkg/maigo/response_body.go
@@ -3,7 +3,6 @@ package maigo
 import (
 	"bytes"
 	"encoding/json"
-	"encoding/xml"
 	"fmt"
 	"io"
 
@@ -62,13 +61,8 @@ func (r *ResponseBody) AsString() (string, error) {
 }
 
 // AsXML decodes the body as XML into a new instance of T.
-func (r *ResponseBody) AsXML[T any]() (T, error) {
-       return AsXML[T](r)
-}
-
-// AsXML decodes the body as XML into a new instance of T.
 func AsXML[T any](r *ResponseBody) (T, error) {
-       defer r.Close()
+	defer r.Close()
 
 	var v T
 	if err := r.body.ReadAsXML(&v); err != nil {

--- a/pkg/maigo/response_body.go
+++ b/pkg/maigo/response_body.go
@@ -61,21 +61,14 @@ func (r *ResponseBody) AsString() (string, error) {
 	return r.body.ReadAsString()
 }
 
-// AsXML implements contracts.ResponseFluentBody.
-//
-// Deprecated: Use [AsXML] generic function instead.
-func (r *ResponseBody) AsXML(v any) error {
-	raw, err := AsXML[[]byte](r)
-	if err != nil {
-		return err
-	}
-
-	return xml.Unmarshal(raw, v)
+// AsXML decodes the body as XML into a new instance of T.
+func (r *ResponseBody) AsXML[T any]() (T, error) {
+       return AsXML[T](r)
 }
 
 // AsXML decodes the body as XML into a new instance of T.
 func AsXML[T any](r *ResponseBody) (T, error) {
-	defer r.Close()
+       defer r.Close()
 
 	var v T
 	if err := r.body.ReadAsXML(&v); err != nil {


### PR DESCRIPTION
## Summary
- add type-parameterized `AsXML` on `ResponseBody`
- remove deprecated `AsXML(v any)` and update contracts

## Testing
- `go vet ./...` *(fails: method must have no type parameters)*
- `go test ./...` *(fails: method must have no type parameters)*

------
https://chatgpt.com/codex/tasks/task_e_68a5f8b6e8d88322b2e54576335c4c38

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Novos Recursos
  - Introduzida API genérica e tipada para decodificação de XML diretamente do corpo da resposta.
- Refatoração
  - Removida a operação de decodificação XML do leitor fluente do corpo da resposta, consolidando a lógica em uma única API tipada; pode exigir ajustes na integração existente.
- Observações
  - Decodificação JSON e operações de leitura (raw, bytes, string) permanecem inalteradas.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->