### PR TITLE
chore: rename module to maigo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-[![Go Reference](https://pkg.go.dev/badge/github.com/jeanmolossi/MaiGo.svg)](https://pkg.go.dev/github.com/jeanmolossi/MaiGo)
-[![CI](https://github.com/jeanmolossi/MaiGo/actions/workflows/ci.yml/badge.svg)](https://github.com/jeanmolossi/MaiGo/actions/workflows/ci.yml)
+[![Go Reference](https://pkg.go.dev/badge/github.com/jeanmolossi/maigo.svg)](https://pkg.go.dev/github.com/jeanmolossi/maigo)
+[![CI](https://github.com/jeanmolossi/maigo/actions/workflows/ci.yml/badge.svg)](https://github.com/jeanmolossi/maigo/actions/workflows/ci.yml)
 
 # MaiGo
 

--- a/async/async.go
+++ b/async/async.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"sync"
 
-	"github.com/jeanmolossi/MaiGo/pkg/maigo/contracts"
+	"github.com/jeanmolossi/maigo/pkg/maigo/contracts"
 )
 
 type result struct {

--- a/async/async_test.go
+++ b/async/async_test.go
@@ -7,8 +7,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/jeanmolossi/MaiGo/pkg/maigo"
-	"github.com/jeanmolossi/MaiGo/pkg/maigo/contracts"
+	"github.com/jeanmolossi/maigo/pkg/maigo"
+	"github.com/jeanmolossi/maigo/pkg/maigo/contracts"
 )
 
 func makeDelayedServer(delay time.Duration) *httptest.Server {

--- a/examples/async_dispatch/main.go
+++ b/examples/async_dispatch/main.go
@@ -4,10 +4,10 @@ import (
 	"log/slog"
 	"time"
 
-	"github.com/jeanmolossi/MaiGo/async"
-	"github.com/jeanmolossi/MaiGo/examples/testserver"
-	"github.com/jeanmolossi/MaiGo/pkg/maigo"
-	"github.com/jeanmolossi/MaiGo/pkg/maigo/header"
+	"github.com/jeanmolossi/maigo/async"
+	"github.com/jeanmolossi/maigo/examples/testserver"
+	"github.com/jeanmolossi/maigo/pkg/maigo"
+	"github.com/jeanmolossi/maigo/pkg/maigo/header"
 )
 
 func main() {

--- a/examples/base_get_request/main.go
+++ b/examples/base_get_request/main.go
@@ -3,9 +3,9 @@ package main
 import (
 	"log/slog"
 
-	"github.com/jeanmolossi/MaiGo/examples/testserver"
-	"github.com/jeanmolossi/MaiGo/pkg/maigo"
-	"github.com/jeanmolossi/MaiGo/pkg/maigo/contracts"
+	"github.com/jeanmolossi/maigo/examples/testserver"
+	"github.com/jeanmolossi/maigo/pkg/maigo"
+	"github.com/jeanmolossi/maigo/pkg/maigo/contracts"
 )
 
 func main() {

--- a/examples/cancelable_request/main.go
+++ b/examples/cancelable_request/main.go
@@ -5,9 +5,9 @@ import (
 	"log/slog"
 	"time"
 
-	"github.com/jeanmolossi/MaiGo/async"
-	"github.com/jeanmolossi/MaiGo/examples/testserver"
-	"github.com/jeanmolossi/MaiGo/pkg/maigo"
+	"github.com/jeanmolossi/maigo/async"
+	"github.com/jeanmolossi/maigo/examples/testserver"
+	"github.com/jeanmolossi/maigo/pkg/maigo"
 )
 
 func main() {

--- a/examples/custom_headers_and_cookies/main.go
+++ b/examples/custom_headers_and_cookies/main.go
@@ -4,9 +4,9 @@ import (
 	"log/slog"
 	"net/http"
 
-	"github.com/jeanmolossi/MaiGo/examples/testserver"
-	"github.com/jeanmolossi/MaiGo/pkg/maigo"
-	"github.com/jeanmolossi/MaiGo/pkg/maigo/mime"
+	"github.com/jeanmolossi/maigo/examples/testserver"
+	"github.com/jeanmolossi/maigo/pkg/maigo"
+	"github.com/jeanmolossi/maigo/pkg/maigo/mime"
 )
 
 func main() {

--- a/examples/load_balancing/main.go
+++ b/examples/load_balancing/main.go
@@ -3,9 +3,9 @@ package main
 import (
 	"log/slog"
 
-	"github.com/jeanmolossi/MaiGo/examples/testserver"
-	"github.com/jeanmolossi/MaiGo/pkg/maigo"
-	"github.com/jeanmolossi/MaiGo/pkg/maigo/contracts"
+	"github.com/jeanmolossi/maigo/examples/testserver"
+	"github.com/jeanmolossi/maigo/pkg/maigo"
+	"github.com/jeanmolossi/maigo/pkg/maigo/contracts"
 )
 
 func main() {

--- a/examples/post_request_with_json/main.go
+++ b/examples/post_request_with_json/main.go
@@ -4,8 +4,8 @@ import (
 	"log/slog"
 	"time"
 
-	"github.com/jeanmolossi/MaiGo/examples/testserver"
-	"github.com/jeanmolossi/MaiGo/pkg/maigo"
+	"github.com/jeanmolossi/maigo/examples/testserver"
+	"github.com/jeanmolossi/maigo/pkg/maigo"
 )
 
 func main() {

--- a/examples/request_group/main.go
+++ b/examples/request_group/main.go
@@ -4,9 +4,9 @@ import (
 	"log/slog"
 	"time"
 
-	"github.com/jeanmolossi/MaiGo/async"
-	"github.com/jeanmolossi/MaiGo/examples/testserver"
-	"github.com/jeanmolossi/MaiGo/pkg/maigo"
+	"github.com/jeanmolossi/maigo/async"
+	"github.com/jeanmolossi/maigo/examples/testserver"
+	"github.com/jeanmolossi/maigo/pkg/maigo"
 )
 
 func main() {

--- a/examples/request_with_tracing/main.go
+++ b/examples/request_with_tracing/main.go
@@ -7,8 +7,8 @@ import (
 	"log"
 	"os"
 
-	"github.com/jeanmolossi/MaiGo/examples/testserver"
-	"github.com/jeanmolossi/MaiGo/pkg/maigo"
+	"github.com/jeanmolossi/maigo/examples/testserver"
+	"github.com/jeanmolossi/maigo/pkg/maigo"
 	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/baggage"

--- a/examples/retry_on_server_error/main.go
+++ b/examples/retry_on_server_error/main.go
@@ -4,8 +4,8 @@ import (
 	"log/slog"
 	"time"
 
-	"github.com/jeanmolossi/MaiGo/examples/testserver"
-	"github.com/jeanmolossi/MaiGo/pkg/maigo"
+	"github.com/jeanmolossi/maigo/examples/testserver"
+	"github.com/jeanmolossi/maigo/pkg/maigo"
 )
 
 func main() {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/jeanmolossi/MaiGo
+module github.com/jeanmolossi/maigo
 
 go 1.24.4
 

--- a/pkg/httpx/logger/example_logger_round_tripper_test.go
+++ b/pkg/httpx/logger/example_logger_round_tripper_test.go
@@ -7,8 +7,8 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/jeanmolossi/MaiGo/pkg/httpx"
-	"github.com/jeanmolossi/MaiGo/pkg/httpx/logger"
+	"github.com/jeanmolossi/maigo/pkg/httpx"
+	"github.com/jeanmolossi/maigo/pkg/httpx/logger"
 )
 
 // ExampleLoggerRoundTripper demonstrates how to chain the logging round tripper

--- a/pkg/httpx/logger/round_tripper.go
+++ b/pkg/httpx/logger/round_tripper.go
@@ -7,7 +7,7 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/jeanmolossi/MaiGo/pkg/httpx"
+	"github.com/jeanmolossi/maigo/pkg/httpx"
 )
 
 // defaultMaxLogBodySize limits how many bytes from request and response bodies are logged.

--- a/pkg/httpx/logger/round_tripper_test.go
+++ b/pkg/httpx/logger/round_tripper_test.go
@@ -9,8 +9,8 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/jeanmolossi/MaiGo/pkg/httpx"
-	"github.com/jeanmolossi/MaiGo/pkg/httpx/logger"
+	"github.com/jeanmolossi/maigo/pkg/httpx"
+	"github.com/jeanmolossi/maigo/pkg/httpx/logger"
 	"github.com/stretchr/testify/require"
 )
 

--- a/pkg/httpx/retry/round_tripper.go
+++ b/pkg/httpx/retry/round_tripper.go
@@ -11,7 +11,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/jeanmolossi/MaiGo/pkg/httpx"
+	"github.com/jeanmolossi/maigo/pkg/httpx"
 )
 
 const (

--- a/pkg/httpx/retry/round_tripper_test.go
+++ b/pkg/httpx/retry/round_tripper_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/jeanmolossi/MaiGo/pkg/httpx"
+	"github.com/jeanmolossi/maigo/pkg/httpx"
 	"github.com/stretchr/testify/require"
 )
 

--- a/pkg/maigo/base_url.go
+++ b/pkg/maigo/base_url.go
@@ -4,7 +4,7 @@ import (
 	"net/url"
 	"sync/atomic"
 
-	"github.com/jeanmolossi/MaiGo/pkg/maigo/contracts"
+	"github.com/jeanmolossi/maigo/pkg/maigo/contracts"
 )
 
 type (

--- a/pkg/maigo/body.go
+++ b/pkg/maigo/body.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/jeanmolossi/MaiGo/pkg/maigo/contracts"
+	"github.com/jeanmolossi/maigo/pkg/maigo/contracts"
 )
 
 var (

--- a/pkg/maigo/client.go
+++ b/pkg/maigo/client.go
@@ -4,7 +4,7 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/jeanmolossi/MaiGo/pkg/maigo/contracts"
+	"github.com/jeanmolossi/maigo/pkg/maigo/contracts"
 )
 
 // interface implementation type check.

--- a/pkg/maigo/client_builder.go
+++ b/pkg/maigo/client_builder.go
@@ -1,6 +1,6 @@
 package maigo
 
-import "github.com/jeanmolossi/MaiGo/pkg/maigo/contracts"
+import "github.com/jeanmolossi/maigo/pkg/maigo/contracts"
 
 var _ contracts.Builder[contracts.ClientHTTPMethods] = (*ClientBuilder)(nil)
 

--- a/pkg/maigo/client_config.go
+++ b/pkg/maigo/client_config.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"net/url"
 
-	"github.com/jeanmolossi/MaiGo/pkg/maigo/contracts"
-	"github.com/jeanmolossi/MaiGo/pkg/maigo/method"
+	"github.com/jeanmolossi/maigo/pkg/maigo/contracts"
+	"github.com/jeanmolossi/maigo/pkg/maigo/method"
 )
 
 var (

--- a/pkg/maigo/client_config_builder.go
+++ b/pkg/maigo/client_config_builder.go
@@ -6,7 +6,7 @@ import (
 	"net/url"
 	"time"
 
-	"github.com/jeanmolossi/MaiGo/pkg/maigo/contracts"
+	"github.com/jeanmolossi/maigo/pkg/maigo/contracts"
 )
 
 var _ contracts.BuilderHTTPClientConfig[contracts.ClientBuilder] = (*ClientConfigBuilder)(nil)

--- a/pkg/maigo/client_cookie_builder.go
+++ b/pkg/maigo/client_cookie_builder.go
@@ -3,7 +3,7 @@ package maigo
 import (
 	"net/http"
 
-	"github.com/jeanmolossi/MaiGo/pkg/maigo/contracts"
+	"github.com/jeanmolossi/maigo/pkg/maigo/contracts"
 )
 
 var _ contracts.BuilderCookie[contracts.ClientBuilder] = (*ClientCookieBuilder)(nil)

--- a/pkg/maigo/client_header_builder.go
+++ b/pkg/maigo/client_header_builder.go
@@ -1,9 +1,9 @@
 package maigo
 
 import (
-	"github.com/jeanmolossi/MaiGo/pkg/maigo/contracts"
-	"github.com/jeanmolossi/MaiGo/pkg/maigo/header"
-	"github.com/jeanmolossi/MaiGo/pkg/maigo/mime"
+	"github.com/jeanmolossi/maigo/pkg/maigo/contracts"
+	"github.com/jeanmolossi/maigo/pkg/maigo/header"
+	"github.com/jeanmolossi/maigo/pkg/maigo/mime"
 )
 
 var _ contracts.BuilderHeader[contracts.ClientBuilder] = (*ClientHeaderBuilder)(nil)

--- a/pkg/maigo/context.go
+++ b/pkg/maigo/context.go
@@ -3,7 +3,7 @@ package maigo
 import (
 	"context"
 
-	"github.com/jeanmolossi/MaiGo/pkg/maigo/contracts"
+	"github.com/jeanmolossi/maigo/pkg/maigo/contracts"
 )
 
 var _ contracts.Context = (*Context)(nil)

--- a/pkg/maigo/contracts/client.go
+++ b/pkg/maigo/contracts/client.go
@@ -7,8 +7,8 @@ import (
 	"net/url"
 	"time"
 
-	"github.com/jeanmolossi/MaiGo/pkg/maigo/header"
-	"github.com/jeanmolossi/MaiGo/pkg/maigo/mime"
+	"github.com/jeanmolossi/maigo/pkg/maigo/header"
+	"github.com/jeanmolossi/maigo/pkg/maigo/mime"
 )
 
 // Client combines configuration and the ability to create HTTP requests for

--- a/pkg/maigo/contracts/headers.go
+++ b/pkg/maigo/contracts/headers.go
@@ -3,7 +3,7 @@ package contracts
 import (
 	"net/http"
 
-	"github.com/jeanmolossi/MaiGo/pkg/maigo/header"
+	"github.com/jeanmolossi/maigo/pkg/maigo/header"
 )
 
 // Header is the interface that wraps the basic methods for managing HTTP headers.

--- a/pkg/maigo/cookie.go
+++ b/pkg/maigo/cookie.go
@@ -3,7 +3,7 @@ package maigo
 import (
 	"net/http"
 
-	"github.com/jeanmolossi/MaiGo/pkg/maigo/contracts"
+	"github.com/jeanmolossi/maigo/pkg/maigo/contracts"
 )
 
 var _ contracts.Cookies = (*Cookies)(nil)

--- a/pkg/maigo/header.go
+++ b/pkg/maigo/header.go
@@ -3,8 +3,8 @@ package maigo
 import (
 	"net/http"
 
-	"github.com/jeanmolossi/MaiGo/pkg/maigo/contracts"
-	"github.com/jeanmolossi/MaiGo/pkg/maigo/header"
+	"github.com/jeanmolossi/maigo/pkg/maigo/contracts"
+	"github.com/jeanmolossi/maigo/pkg/maigo/header"
 )
 
 var _ contracts.Header = (*Header)(nil)

--- a/pkg/maigo/request.go
+++ b/pkg/maigo/request.go
@@ -1,8 +1,8 @@
 package maigo
 
 import (
-	"github.com/jeanmolossi/MaiGo/pkg/maigo/contracts"
-	"github.com/jeanmolossi/MaiGo/pkg/maigo/method"
+	"github.com/jeanmolossi/maigo/pkg/maigo/contracts"
+	"github.com/jeanmolossi/maigo/pkg/maigo/method"
 )
 
 type Request struct {

--- a/pkg/maigo/request_body_builder.go
+++ b/pkg/maigo/request_body_builder.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 	"io"
 
-	"github.com/jeanmolossi/MaiGo/pkg/maigo/contracts"
+	"github.com/jeanmolossi/maigo/pkg/maigo/contracts"
 )
 
 var _ contracts.BuilderRequestBody[contracts.RequestBuilder] = (*RequestBodyBuilder)(nil)

--- a/pkg/maigo/request_builder.go
+++ b/pkg/maigo/request_builder.go
@@ -14,8 +14,8 @@ import (
 	"sync"
 	"time"
 
-	"github.com/jeanmolossi/MaiGo/pkg/maigo/contracts"
-	"github.com/jeanmolossi/MaiGo/pkg/maigo/header"
+	"github.com/jeanmolossi/maigo/pkg/maigo/contracts"
+	"github.com/jeanmolossi/maigo/pkg/maigo/header"
 )
 
 var _ contracts.RequestBuilder = (*RequestBuilder)(nil)

--- a/pkg/maigo/request_config_base.go
+++ b/pkg/maigo/request_config_base.go
@@ -4,8 +4,8 @@ import (
 	"net/url"
 	"time"
 
-	"github.com/jeanmolossi/MaiGo/pkg/maigo/contracts"
-	"github.com/jeanmolossi/MaiGo/pkg/maigo/method"
+	"github.com/jeanmolossi/maigo/pkg/maigo/contracts"
+	"github.com/jeanmolossi/maigo/pkg/maigo/method"
 )
 
 type (

--- a/pkg/maigo/request_context_builder.go
+++ b/pkg/maigo/request_context_builder.go
@@ -3,7 +3,7 @@ package maigo
 import (
 	"context"
 
-	"github.com/jeanmolossi/MaiGo/pkg/maigo/contracts"
+	"github.com/jeanmolossi/maigo/pkg/maigo/contracts"
 )
 
 var _ contracts.BuilderRequestContext[contracts.RequestBuilder] = (*RequestContextBuilder)(nil)

--- a/pkg/maigo/request_header_builder.go
+++ b/pkg/maigo/request_header_builder.go
@@ -1,9 +1,9 @@
 package maigo
 
 import (
-	"github.com/jeanmolossi/MaiGo/pkg/maigo/contracts"
-	"github.com/jeanmolossi/MaiGo/pkg/maigo/header"
-	"github.com/jeanmolossi/MaiGo/pkg/maigo/mime"
+	"github.com/jeanmolossi/maigo/pkg/maigo/contracts"
+	"github.com/jeanmolossi/maigo/pkg/maigo/header"
+	"github.com/jeanmolossi/maigo/pkg/maigo/mime"
 )
 
 var _ contracts.BuilderHeader[contracts.RequestBuilder] = (*RequestHeaderBuilder)(nil)

--- a/pkg/maigo/request_query_builder.go
+++ b/pkg/maigo/request_query_builder.go
@@ -5,7 +5,7 @@ import (
 	"net/url"
 	"strings"
 
-	"github.com/jeanmolossi/MaiGo/pkg/maigo/contracts"
+	"github.com/jeanmolossi/maigo/pkg/maigo/contracts"
 )
 
 var _ contracts.BuilderRequestQuery[contracts.RequestBuilder] = (*RequestQueryBuilder)(nil)

--- a/pkg/maigo/request_retry_builder.go
+++ b/pkg/maigo/request_retry_builder.go
@@ -3,7 +3,7 @@ package maigo
 import (
 	"time"
 
-	"github.com/jeanmolossi/MaiGo/pkg/maigo/contracts"
+	"github.com/jeanmolossi/maigo/pkg/maigo/contracts"
 )
 
 var _ contracts.BuilderRequestRetry[contracts.RequestBuilder] = (*RequestRetryBuilder)(nil)

--- a/pkg/maigo/response.go
+++ b/pkg/maigo/response.go
@@ -3,7 +3,7 @@ package maigo
 import (
 	"net/http"
 
-	"github.com/jeanmolossi/MaiGo/pkg/maigo/contracts"
+	"github.com/jeanmolossi/maigo/pkg/maigo/contracts"
 )
 
 var _ contracts.Response = (*Response)(nil)

--- a/pkg/maigo/response_body.go
+++ b/pkg/maigo/response_body.go
@@ -7,7 +7,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/jeanmolossi/MaiGo/pkg/maigo/contracts"
+	"github.com/jeanmolossi/maigo/pkg/maigo/contracts"
 )
 
 var _ contracts.ResponseFluentBody = (*ResponseBody)(nil)

--- a/pkg/maigo/response_cookie.go
+++ b/pkg/maigo/response_cookie.go
@@ -3,7 +3,7 @@ package maigo
 import (
 	"net/http"
 
-	"github.com/jeanmolossi/MaiGo/pkg/maigo/contracts"
+	"github.com/jeanmolossi/maigo/pkg/maigo/contracts"
 )
 
 var _ contracts.ResponseFluentCookie = (*ResponseCookie)(nil)

--- a/pkg/maigo/response_header.go
+++ b/pkg/maigo/response_header.go
@@ -3,7 +3,7 @@ package maigo
 import (
 	"net/http"
 
-	"github.com/jeanmolossi/MaiGo/pkg/maigo/contracts"
+	"github.com/jeanmolossi/maigo/pkg/maigo/contracts"
 )
 
 var _ contracts.ResponseFluentHeader = (*ResponseHeader)(nil)

--- a/pkg/maigo/response_request.go
+++ b/pkg/maigo/response_request.go
@@ -3,7 +3,7 @@ package maigo
 import (
 	"net/http"
 
-	"github.com/jeanmolossi/MaiGo/pkg/maigo/contracts"
+	"github.com/jeanmolossi/maigo/pkg/maigo/contracts"
 )
 
 var _ contracts.ResponseFluentRequest = (*ResponseRequest)(nil)

--- a/pkg/maigo/response_status.go
+++ b/pkg/maigo/response_status.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/jeanmolossi/MaiGo/pkg/maigo/contracts"
+	"github.com/jeanmolossi/maigo/pkg/maigo/contracts"
 )
 
 var _ contracts.ResponseFluentStatus = (*ResponseStatus)(nil)

--- a/pkg/maigo/validations.go
+++ b/pkg/maigo/validations.go
@@ -1,6 +1,6 @@
 package maigo
 
-import "github.com/jeanmolossi/MaiGo/pkg/maigo/contracts"
+import "github.com/jeanmolossi/maigo/pkg/maigo/contracts"
 
 var _ contracts.Validations = (*Validations)(nil)
 


### PR DESCRIPTION
## Summary
- rename module to `github.com/jeanmolossi/maigo`
- update imports and docs to new module path
- tidy modules and format code

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68a928ffc78c83229f0fb390ff599129

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Documentação
  - Atualiza os badges do README para refletir o novo nome/URL do projeto.
- Chores
  - Padroniza o namespace do módulo para “maigo” em todo o código e exemplos, garantindo consistência nas referências.
  - Consumidores do pacote devem atualizar seus imports para o novo caminho.
- Tests
  - Ajusta os testes para usar o novo caminho do pacote; sem alterações de comportamento.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->