### PR TITLE
ci: add goreleaser release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,36 @@
+name: Release
+
+on:
+    push:
+        branches: ["main"]
+
+permissions:
+    contents: write
+    packages: write
+
+jobs:
+    goreleaser:
+        if: startsWith(github.event.head_commit.message, 'Merge pull request')
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v4
+
+            - name: Setup Go
+              uses: actions/setup-go@v4
+              with:
+                  go-version-file: go.mod
+
+            - name: Generate changelog
+              uses: goreleaser/goreleaser-action@v5
+              with:
+                  args: changelog --output=CHANGELOG.md
+              env:
+                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+            - name: Run GoReleaser
+              uses: goreleaser/goreleaser-action@v5
+              with:
+                  args: release --clean --release-notes=CHANGELOG.md
+              env:
+                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -32,6 +32,10 @@ if err := resp.Body().AsJSON(&users); err != nil {
 
 Outros exemplos estão disponíveis na pasta `examples`, incluindo chamadas com cabeçalhos customizados, balanceamento de carga e *tracing* com OpenTelemetry. E não se surpreenda se surgir uma nova referência à Mai no meio dos logs.
 
+## Releases
+As releases são geradas automaticamente ao mesclar alterações no branch `main`.
+O workflow [`release.yml`](.github/workflows/release.yml) usa [GoReleaser](https://goreleaser.com/) para criar tags, gerar changelog e publicar pacotes utilizando o `GITHUB_TOKEN` com permissões de `contents: write` e `packages: write`.
+
 ## Contributing
 Contribuições são muito bem-vindas! Para colaborar:
 1. Fork este repositório.


### PR DESCRIPTION
## Summary
- add release workflow using GoReleaser
- document automated release process in README

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68a931b85b448322a7ab237a2412c51d