### PR TITLE
ci: allow release workflow to run on squash merges

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
     goreleaser:
-        if: startsWith(github.event.head_commit.message, 'Merge pull request')
+        if: startsWith(github.event.head_commit.message, 'Merge pull request') || contains(github.event.head_commit.message, '(#')
         runs-on: ubuntu-latest
         steps:
             - name: Checkout


### PR DESCRIPTION
## Summary
- allow release workflow to run on squash merges

## Testing
- `python - <<'PY'
import yaml
with open('.github/workflows/release.yml') as f:
    yaml.safe_load(f)
print('YAML is valid')
PY`


------
https://chatgpt.com/codex/tasks/task_e_68a935a0b3f48322a00bca90430971b5