### PR TITLE
test: add body read write and concurrency tests

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,5 @@
 ## v1.1.4
 
+- fix data race in UnbufferedBody by using write locks
+- add tests for body read/write helpers and concurrency safety
 - lint-only changes

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,4 +1,4 @@
-## v1.1.4
+## v1.2.5
 
 - fix data race in UnbufferedBody by using write locks
 - add tests for body read/write helpers and concurrency safety

--- a/pkg/maigo/body.go
+++ b/pkg/maigo/body.go
@@ -58,16 +58,16 @@ func (u *UnbufferedBody) ReadAsJSON(obj any) (err error) {
 
 	data, err := io.ReadAll(prev)
 	if err != nil {
+		_ = prev.Close()
 		return fmt.Errorf("failed reading body as JSON: %w", err)
 	}
+
+	u.reader = io.NopCloser(bytes.NewReader(data))
+	_ = prev.Close()
 
 	if err = json.Unmarshal(data, obj); err != nil {
 		return fmt.Errorf("failed decoding body as JSON: %w", err)
 	}
-
-	u.reader = io.NopCloser(bytes.NewReader(data))
-
-	_ = prev.Close()
 
 	return nil
 }
@@ -100,16 +100,16 @@ func (u *UnbufferedBody) ReadAsXML(obj any) (err error) {
 
 	data, err := io.ReadAll(prev)
 	if err != nil {
+		_ = prev.Close()
 		return fmt.Errorf("failed reading body as XML: %w", err)
 	}
+
+	u.reader = io.NopCloser(bytes.NewReader(data))
+	_ = prev.Close()
 
 	if err = xml.Unmarshal(data, obj); err != nil {
 		return fmt.Errorf("failed decoding body as XML: %w", err)
 	}
-
-	u.reader = io.NopCloser(bytes.NewReader(data))
-
-	_ = prev.Close()
 
 	return nil
 }

--- a/pkg/maigo/body.go
+++ b/pkg/maigo/body.go
@@ -185,6 +185,7 @@ func (b *BufferedBody) ReadAsJSON(obj any) (err error) {
 // WriteAsJSON implements contracts.Body.
 func (b *BufferedBody) WriteAsJSON(obj any) (err error) {
 	b.mutex.Lock()
+	b.buffer.Reset()
 	err = json.NewEncoder(b.buffer).Encode(obj)
 	b.mutex.Unlock()
 
@@ -203,6 +204,7 @@ func (b *BufferedBody) ReadAsString() (str string, err error) {
 // WriteAsString implements contracts.Body.
 func (b *BufferedBody) WriteAsString(body string) (err error) {
 	b.mutex.Lock()
+	b.buffer.Reset()
 	_, err = b.buffer.WriteString(body)
 	b.mutex.Unlock()
 
@@ -221,6 +223,7 @@ func (b *BufferedBody) ReadAsXML(obj any) (err error) {
 // WriteAsXML implements contracts.Body.
 func (b *BufferedBody) WriteAsXML(obj any) (err error) {
 	b.mutex.Lock()
+	b.buffer.Reset()
 	err = xml.NewEncoder(b.buffer).Encode(obj)
 	b.mutex.Unlock()
 

--- a/pkg/maigo/body.go
+++ b/pkg/maigo/body.go
@@ -40,18 +40,18 @@ func (u *UnbufferedBody) Close() (err error) {
 
 // Read implements contracts.Body.
 func (u *UnbufferedBody) Read(p []byte) (n int, err error) {
-	u.mutex.RLock()
+	u.mutex.Lock()
 	n, err = u.reader.Read(p)
-	u.mutex.RUnlock()
+	u.mutex.Unlock()
 
 	return
 }
 
 // ReadAsJSON implements contracts.Body.
 func (u *UnbufferedBody) ReadAsJSON(obj any) (err error) {
-	u.mutex.RLock()
+	u.mutex.Lock()
 	err = json.NewDecoder(u.reader).Decode(obj)
-	u.mutex.RUnlock()
+	u.mutex.Unlock()
 
 	return
 }
@@ -75,9 +75,9 @@ func (u *UnbufferedBody) WriteAsJSON(obj any) (err error) {
 
 // ReadAsXML implements contracts.Body.
 func (u *UnbufferedBody) ReadAsXML(obj any) (err error) {
-	u.mutex.RLock()
+	u.mutex.Lock()
 	err = xml.NewDecoder(u.reader).Decode(obj)
-	u.mutex.RUnlock()
+	u.mutex.Unlock()
 
 	return
 }
@@ -101,8 +101,8 @@ func (u *UnbufferedBody) WriteAsXML(obj any) (err error) {
 
 // ReadAsString implements contracts.Body.
 func (u *UnbufferedBody) ReadAsString() (string, error) {
-	u.mutex.RLock()
-	defer u.mutex.RUnlock()
+	u.mutex.Lock()
+	defer u.mutex.Unlock()
 
 	stringBytes, err := io.ReadAll(u.reader)
 	if err != nil {

--- a/pkg/maigo/body_test.go
+++ b/pkg/maigo/body_test.go
@@ -270,41 +270,91 @@ func TestUnbufferedBodyStringOperations(t *testing.T) {
 func TestUnbufferedBodyJSONOperations(t *testing.T) {
 	t.Parallel()
 
-	body := newUnbufferedBody(io.NopCloser(bytes.NewBuffer(nil)))
-	in := sample{Name: "dan"}
+	t.Run("round trip", func(t *testing.T) {
+		body := newUnbufferedBody(io.NopCloser(bytes.NewBuffer(nil)))
+		in := sample{Name: "dan"}
 
-	if err := body.WriteAsJSON(in); err != nil {
-		t.Fatalf("WriteAsJSON() error = %v", err)
-	}
+		if err := body.WriteAsJSON(in); err != nil {
+			t.Fatalf("WriteAsJSON() error = %v", err)
+		}
 
-	var out sample
-	if err := body.ReadAsJSON(&out); err != nil {
-		t.Fatalf("ReadAsJSON() error = %v", err)
-	}
+		var out sample
+		if err := body.ReadAsJSON(&out); err != nil {
+			t.Fatalf("ReadAsJSON() error = %v", err)
+		}
 
-	if out != in {
-		t.Errorf("ReadAsJSON() = %#v, want %#v", out, in)
-	}
+		if out != in {
+			t.Errorf("ReadAsJSON() = %#v, want %#v", out, in)
+		}
+	})
+
+	t.Run("rewrite replaces content", func(t *testing.T) {
+		body := newUnbufferedBody(io.NopCloser(bytes.NewBuffer(nil)))
+		first := sample{Name: "first"}
+		second := sample{Name: "second"}
+
+		if err := body.WriteAsJSON(first); err != nil {
+			t.Fatalf("WriteAsJSON() first write error = %v", err)
+		}
+
+		if err := body.WriteAsJSON(second); err != nil {
+			t.Fatalf("WriteAsJSON() second write error = %v", err)
+		}
+
+		var out sample
+		if err := body.ReadAsJSON(&out); err != nil {
+			t.Fatalf("ReadAsJSON() after rewrite error = %v", err)
+		}
+
+		if out != second {
+			t.Errorf("ReadAsJSON() after rewrite = %#v, want %#v", out, second)
+		}
+	})
 }
 
 func TestUnbufferedBodyXMLOperations(t *testing.T) {
 	t.Parallel()
 
-	body := newUnbufferedBody(io.NopCloser(bytes.NewBuffer(nil)))
-	in := sample{Name: "eric"}
+	t.Run("round trip", func(t *testing.T) {
+		body := newUnbufferedBody(io.NopCloser(bytes.NewBuffer(nil)))
+		in := sample{Name: "eric"}
 
-	if err := body.WriteAsXML(in); err != nil {
-		t.Fatalf("WriteAsXML() error = %v", err)
-	}
+		if err := body.WriteAsXML(in); err != nil {
+			t.Fatalf("WriteAsXML() error = %v", err)
+		}
 
-	var out sample
-	if err := body.ReadAsXML(&out); err != nil {
-		t.Fatalf("ReadAsXML() error = %v", err)
-	}
+		var out sample
+		if err := body.ReadAsXML(&out); err != nil {
+			t.Fatalf("ReadAsXML() error = %v", err)
+		}
 
-	if out != in {
-		t.Errorf("ReadAsXML() = %#v, want %#v", out, in)
-	}
+		if out != in {
+			t.Errorf("ReadAsXML() = %#v, want %#v", out, in)
+		}
+	})
+
+	t.Run("rewrite replaces content", func(t *testing.T) {
+		body := newUnbufferedBody(io.NopCloser(bytes.NewBuffer(nil)))
+		first := sample{Name: "first"}
+		second := sample{Name: "second"}
+
+		if err := body.WriteAsXML(first); err != nil {
+			t.Fatalf("WriteAsXML() first write error = %v", err)
+		}
+
+		if err := body.WriteAsXML(second); err != nil {
+			t.Fatalf("WriteAsXML() second write error = %v", err)
+		}
+
+		var out sample
+		if err := body.ReadAsXML(&out); err != nil {
+			t.Fatalf("ReadAsXML() after rewrite error = %v", err)
+		}
+
+		if out != second {
+			t.Errorf("ReadAsXML() after rewrite = %#v, want %#v", out, second)
+		}
+	})
 }
 
 func TestUnbufferedBodyInvalidData(t *testing.T) {

--- a/pkg/maigo/body_test.go
+++ b/pkg/maigo/body_test.go
@@ -71,11 +71,20 @@ func TestBufferedBodyJSONOperations(t *testing.T) {
 
 		var out sample
 		if err := body.ReadAsJSON(&out); err != nil {
-			t.Fatalf("ReadAsJSON() error = %v", err)
+			t.Fatalf("ReadAsJSON() first read error = %v", err)
 		}
 
 		if out != in {
-			t.Errorf("ReadAsJSON() = %#v, want %#v", out, in)
+			t.Errorf("ReadAsJSON() first read = %#v, want %#v", out, in)
+		}
+
+		var outAgain sample
+		if err := body.ReadAsJSON(&outAgain); err != nil {
+			t.Fatalf("ReadAsJSON() second read error = %v", err)
+		}
+
+		if outAgain != in {
+			t.Errorf("ReadAsJSON() second read = %#v, want %#v", outAgain, in)
 		}
 	})
 
@@ -116,11 +125,20 @@ func TestBufferedBodyXMLOperations(t *testing.T) {
 
 		var out sample
 		if err := body.ReadAsXML(&out); err != nil {
-			t.Fatalf("ReadAsXML() error = %v", err)
+			t.Fatalf("ReadAsXML() first read error = %v", err)
 		}
 
 		if out != in {
-			t.Errorf("ReadAsXML() = %#v, want %#v", out, in)
+			t.Errorf("ReadAsXML() first read = %#v, want %#v", out, in)
+		}
+
+		var outAgain sample
+		if err := body.ReadAsXML(&outAgain); err != nil {
+			t.Fatalf("ReadAsXML() second read error = %v", err)
+		}
+
+		if outAgain != in {
+			t.Errorf("ReadAsXML() second read = %#v, want %#v", outAgain, in)
 		}
 	})
 

--- a/pkg/maigo/body_test.go
+++ b/pkg/maigo/body_test.go
@@ -15,6 +15,7 @@ func TestBufferedBodyStringOperations(t *testing.T) {
 	t.Parallel()
 
 	body := newBufferedBody()
+
 	const want = "hello"
 
 	if err := body.WriteAsString(want); err != nil {
@@ -25,6 +26,7 @@ func TestBufferedBodyStringOperations(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ReadAsString() error = %v", err)
 	}
+
 	if got != want {
 		t.Errorf("ReadAsString() = %q, want %q", got, want)
 	}
@@ -34,6 +36,7 @@ func TestBufferedBodyStringOperations(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ReadAsString() second read error = %v", err)
 	}
+
 	if gotAgain != want {
 		t.Errorf("ReadAsString() second read = %q, want %q", gotAgain, want)
 	}
@@ -53,6 +56,7 @@ func TestBufferedBodyJSONOperations(t *testing.T) {
 	if err := body.ReadAsJSON(&out); err != nil {
 		t.Fatalf("ReadAsJSON() error = %v", err)
 	}
+
 	if out != in {
 		t.Errorf("ReadAsJSON() = %#v, want %#v", out, in)
 	}
@@ -72,6 +76,7 @@ func TestBufferedBodyXMLOperations(t *testing.T) {
 	if err := body.ReadAsXML(&out); err != nil {
 		t.Fatalf("ReadAsXML() error = %v", err)
 	}
+
 	if out != in {
 		t.Errorf("ReadAsXML() = %#v, want %#v", out, in)
 	}
@@ -85,6 +90,7 @@ func TestBufferedBodyInvalidData(t *testing.T) {
 	if err := body.WriteAsString("not-json"); err != nil {
 		t.Fatalf("WriteAsString() error = %v", err)
 	}
+
 	var js sample
 	if err := body.ReadAsJSON(&js); err == nil {
 		t.Error("ReadAsJSON() expected error, got nil")
@@ -95,6 +101,7 @@ func TestBufferedBodyInvalidData(t *testing.T) {
 	if err := body.WriteAsString("<invalid>"); err != nil {
 		t.Fatalf("WriteAsString() error = %v", err)
 	}
+
 	var x sample
 	if err := body.ReadAsXML(&x); err == nil {
 		t.Error("ReadAsXML() expected error, got nil")
@@ -114,23 +121,31 @@ func TestBufferedBodyConcurrency(t *testing.T) {
 	t.Parallel()
 
 	body := newBufferedBody()
+
 	const want = "concurrent"
+
 	if err := body.WriteAsString(want); err != nil {
 		t.Fatalf("WriteAsString() error = %v", err)
 	}
 
 	var wg sync.WaitGroup
+
 	errCh := make(chan error, 50)
+
 	for i := 0; i < 50; i++ {
 		wg.Add(1)
+
 		go func() {
 			defer wg.Done()
+
 			_, err := body.ReadAsString()
 			errCh <- err
 		}()
 	}
+
 	wg.Wait()
 	close(errCh)
+
 	for err := range errCh {
 		if err != nil {
 			t.Fatalf("concurrent ReadAsString() error = %v", err)
@@ -143,6 +158,7 @@ func TestUnbufferedBodyStringOperations(t *testing.T) {
 
 	reader := io.NopCloser(bytes.NewBufferString(""))
 	body := newUnbufferedBody(reader)
+
 	const want = "hello"
 
 	if err := body.WriteAsString(want); err != nil {
@@ -153,6 +169,7 @@ func TestUnbufferedBodyStringOperations(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ReadAsString() error = %v", err)
 	}
+
 	if got != want {
 		t.Errorf("ReadAsString() = %q, want %q", got, want)
 	}
@@ -162,6 +179,7 @@ func TestUnbufferedBodyStringOperations(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ReadAsString() second read error = %v", err)
 	}
+
 	if gotAgain != want {
 		t.Errorf("ReadAsString() second read = %q, want %q", gotAgain, want)
 	}
@@ -181,6 +199,7 @@ func TestUnbufferedBodyJSONOperations(t *testing.T) {
 	if err := body.ReadAsJSON(&out); err != nil {
 		t.Fatalf("ReadAsJSON() error = %v", err)
 	}
+
 	if out != in {
 		t.Errorf("ReadAsJSON() = %#v, want %#v", out, in)
 	}
@@ -200,6 +219,7 @@ func TestUnbufferedBodyXMLOperations(t *testing.T) {
 	if err := body.ReadAsXML(&out); err != nil {
 		t.Fatalf("ReadAsXML() error = %v", err)
 	}
+
 	if out != in {
 		t.Errorf("ReadAsXML() = %#v, want %#v", out, in)
 	}
@@ -212,6 +232,7 @@ func TestUnbufferedBodyInvalidData(t *testing.T) {
 	if err := body.WriteAsString("not-json"); err != nil {
 		t.Fatalf("WriteAsString() error = %v", err)
 	}
+
 	var js sample
 	if err := body.ReadAsJSON(&js); err == nil {
 		t.Error("ReadAsJSON() expected error, got nil")
@@ -221,6 +242,7 @@ func TestUnbufferedBodyInvalidData(t *testing.T) {
 	if err := body.WriteAsString("<invalid>"); err != nil {
 		t.Fatalf("WriteAsString() error = %v", err)
 	}
+
 	var x sample
 	if err := body.ReadAsXML(&x); err == nil {
 		t.Error("ReadAsXML() expected error, got nil")
@@ -229,6 +251,7 @@ func TestUnbufferedBodyInvalidData(t *testing.T) {
 	if err := body.WriteAsJSON(func() {}); err == nil {
 		t.Error("WriteAsJSON() expected error for unsupported type")
 	}
+
 	if err := body.WriteAsXML(func() {}); err == nil {
 		t.Error("WriteAsXML() expected error for unsupported type")
 	}
@@ -238,23 +261,31 @@ func TestUnbufferedBodyConcurrency(t *testing.T) {
 	t.Parallel()
 
 	body := newUnbufferedBody(io.NopCloser(bytes.NewBufferString("")))
+
 	const want = "concurrent"
+
 	if err := body.WriteAsString(want); err != nil {
 		t.Fatalf("WriteAsString() error = %v", err)
 	}
 
 	var wg sync.WaitGroup
+
 	errCh := make(chan error, 50)
+
 	for i := 0; i < 50; i++ {
 		wg.Add(1)
+
 		go func() {
 			defer wg.Done()
+
 			_, err := body.ReadAsString()
 			errCh <- err
 		}()
 	}
+
 	wg.Wait()
 	close(errCh)
+
 	for err := range errCh {
 		if err != nil {
 			t.Fatalf("concurrent ReadAsString() error = %v", err)

--- a/pkg/maigo/body_test.go
+++ b/pkg/maigo/body_test.go
@@ -1,0 +1,263 @@
+package maigo
+
+import (
+	"bytes"
+	"io"
+	"sync"
+	"testing"
+)
+
+type sample struct {
+	Name string `json:"name" xml:"name"`
+}
+
+func TestBufferedBodyStringOperations(t *testing.T) {
+	t.Parallel()
+
+	body := newBufferedBody()
+	const want = "hello"
+
+	if err := body.WriteAsString(want); err != nil {
+		t.Fatalf("WriteAsString() error = %v", err)
+	}
+
+	got, err := body.ReadAsString()
+	if err != nil {
+		t.Fatalf("ReadAsString() error = %v", err)
+	}
+	if got != want {
+		t.Errorf("ReadAsString() = %q, want %q", got, want)
+	}
+
+	// Body should not be consumed after read
+	gotAgain, err := body.ReadAsString()
+	if err != nil {
+		t.Fatalf("ReadAsString() second read error = %v", err)
+	}
+	if gotAgain != want {
+		t.Errorf("ReadAsString() second read = %q, want %q", gotAgain, want)
+	}
+}
+
+func TestBufferedBodyJSONOperations(t *testing.T) {
+	t.Parallel()
+
+	body := newBufferedBody()
+	in := sample{Name: "bob"}
+
+	if err := body.WriteAsJSON(in); err != nil {
+		t.Fatalf("WriteAsJSON() error = %v", err)
+	}
+
+	var out sample
+	if err := body.ReadAsJSON(&out); err != nil {
+		t.Fatalf("ReadAsJSON() error = %v", err)
+	}
+	if out != in {
+		t.Errorf("ReadAsJSON() = %#v, want %#v", out, in)
+	}
+}
+
+func TestBufferedBodyXMLOperations(t *testing.T) {
+	t.Parallel()
+
+	body := newBufferedBody()
+	in := sample{Name: "carol"}
+
+	if err := body.WriteAsXML(in); err != nil {
+		t.Fatalf("WriteAsXML() error = %v", err)
+	}
+
+	var out sample
+	if err := body.ReadAsXML(&out); err != nil {
+		t.Fatalf("ReadAsXML() error = %v", err)
+	}
+	if out != in {
+		t.Errorf("ReadAsXML() = %#v, want %#v", out, in)
+	}
+}
+
+func TestBufferedBodyInvalidData(t *testing.T) {
+	t.Parallel()
+
+	body := newBufferedBody()
+	// invalid JSON read
+	if err := body.WriteAsString("not-json"); err != nil {
+		t.Fatalf("WriteAsString() error = %v", err)
+	}
+	var js sample
+	if err := body.ReadAsJSON(&js); err == nil {
+		t.Error("ReadAsJSON() expected error, got nil")
+	}
+
+	// invalid XML read
+	body = newBufferedBody()
+	if err := body.WriteAsString("<invalid>"); err != nil {
+		t.Fatalf("WriteAsString() error = %v", err)
+	}
+	var x sample
+	if err := body.ReadAsXML(&x); err == nil {
+		t.Error("ReadAsXML() expected error, got nil")
+	}
+
+	// invalid JSON write
+	if err := body.WriteAsJSON(func() {}); err == nil {
+		t.Error("WriteAsJSON() expected error for unsupported type")
+	}
+	// invalid XML write
+	if err := body.WriteAsXML(func() {}); err == nil {
+		t.Error("WriteAsXML() expected error for unsupported type")
+	}
+}
+
+func TestBufferedBodyConcurrency(t *testing.T) {
+	t.Parallel()
+
+	body := newBufferedBody()
+	const want = "concurrent"
+	if err := body.WriteAsString(want); err != nil {
+		t.Fatalf("WriteAsString() error = %v", err)
+	}
+
+	var wg sync.WaitGroup
+	errCh := make(chan error, 50)
+	for i := 0; i < 50; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_, err := body.ReadAsString()
+			errCh <- err
+		}()
+	}
+	wg.Wait()
+	close(errCh)
+	for err := range errCh {
+		if err != nil {
+			t.Fatalf("concurrent ReadAsString() error = %v", err)
+		}
+	}
+}
+
+func TestUnbufferedBodyStringOperations(t *testing.T) {
+	t.Parallel()
+
+	reader := io.NopCloser(bytes.NewBufferString(""))
+	body := newUnbufferedBody(reader)
+	const want = "hello"
+
+	if err := body.WriteAsString(want); err != nil {
+		t.Fatalf("WriteAsString() error = %v", err)
+	}
+
+	got, err := body.ReadAsString()
+	if err != nil {
+		t.Fatalf("ReadAsString() error = %v", err)
+	}
+	if got != want {
+		t.Errorf("ReadAsString() = %q, want %q", got, want)
+	}
+
+	// Body should be reset after read
+	gotAgain, err := body.ReadAsString()
+	if err != nil {
+		t.Fatalf("ReadAsString() second read error = %v", err)
+	}
+	if gotAgain != want {
+		t.Errorf("ReadAsString() second read = %q, want %q", gotAgain, want)
+	}
+}
+
+func TestUnbufferedBodyJSONOperations(t *testing.T) {
+	t.Parallel()
+
+	body := newUnbufferedBody(io.NopCloser(bytes.NewBuffer(nil)))
+	in := sample{Name: "dan"}
+
+	if err := body.WriteAsJSON(in); err != nil {
+		t.Fatalf("WriteAsJSON() error = %v", err)
+	}
+
+	var out sample
+	if err := body.ReadAsJSON(&out); err != nil {
+		t.Fatalf("ReadAsJSON() error = %v", err)
+	}
+	if out != in {
+		t.Errorf("ReadAsJSON() = %#v, want %#v", out, in)
+	}
+}
+
+func TestUnbufferedBodyXMLOperations(t *testing.T) {
+	t.Parallel()
+
+	body := newUnbufferedBody(io.NopCloser(bytes.NewBuffer(nil)))
+	in := sample{Name: "eric"}
+
+	if err := body.WriteAsXML(in); err != nil {
+		t.Fatalf("WriteAsXML() error = %v", err)
+	}
+
+	var out sample
+	if err := body.ReadAsXML(&out); err != nil {
+		t.Fatalf("ReadAsXML() error = %v", err)
+	}
+	if out != in {
+		t.Errorf("ReadAsXML() = %#v, want %#v", out, in)
+	}
+}
+
+func TestUnbufferedBodyInvalidData(t *testing.T) {
+	t.Parallel()
+
+	body := newUnbufferedBody(io.NopCloser(bytes.NewBuffer(nil)))
+	if err := body.WriteAsString("not-json"); err != nil {
+		t.Fatalf("WriteAsString() error = %v", err)
+	}
+	var js sample
+	if err := body.ReadAsJSON(&js); err == nil {
+		t.Error("ReadAsJSON() expected error, got nil")
+	}
+
+	body = newUnbufferedBody(io.NopCloser(bytes.NewBuffer(nil)))
+	if err := body.WriteAsString("<invalid>"); err != nil {
+		t.Fatalf("WriteAsString() error = %v", err)
+	}
+	var x sample
+	if err := body.ReadAsXML(&x); err == nil {
+		t.Error("ReadAsXML() expected error, got nil")
+	}
+
+	if err := body.WriteAsJSON(func() {}); err == nil {
+		t.Error("WriteAsJSON() expected error for unsupported type")
+	}
+	if err := body.WriteAsXML(func() {}); err == nil {
+		t.Error("WriteAsXML() expected error for unsupported type")
+	}
+}
+
+func TestUnbufferedBodyConcurrency(t *testing.T) {
+	t.Parallel()
+
+	body := newUnbufferedBody(io.NopCloser(bytes.NewBufferString("")))
+	const want = "concurrent"
+	if err := body.WriteAsString(want); err != nil {
+		t.Fatalf("WriteAsString() error = %v", err)
+	}
+
+	var wg sync.WaitGroup
+	errCh := make(chan error, 50)
+	for i := 0; i < 50; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_, err := body.ReadAsString()
+			errCh <- err
+		}()
+	}
+	wg.Wait()
+	close(errCh)
+	for err := range errCh {
+		if err != nil {
+			t.Fatalf("concurrent ReadAsString() error = %v", err)
+		}
+	}
+}

--- a/pkg/maigo/body_test.go
+++ b/pkg/maigo/body_test.go
@@ -388,6 +388,12 @@ func TestUnbufferedBodyInvalidData(t *testing.T) {
 		t.Error("ReadAsJSON() expected error, got nil")
 	}
 
+	if s, err := body.ReadAsString(); err != nil {
+		t.Fatalf("ReadAsString() after JSON error = %v", err)
+	} else if s != "not-json" {
+		t.Errorf("ReadAsString() after JSON error = %q, want %q", s, "not-json")
+	}
+
 	body = newUnbufferedBody(io.NopCloser(bytes.NewBuffer(nil)))
 	if err := body.WriteAsString("<invalid>"); err != nil {
 		t.Fatalf("WriteAsString() error = %v", err)
@@ -396,6 +402,12 @@ func TestUnbufferedBodyInvalidData(t *testing.T) {
 	var x sample
 	if err := body.ReadAsXML(&x); err == nil {
 		t.Error("ReadAsXML() expected error, got nil")
+	}
+
+	if s, err := body.ReadAsString(); err != nil {
+		t.Fatalf("ReadAsString() after XML error = %v", err)
+	} else if s != "<invalid>" {
+		t.Errorf("ReadAsString() after XML error = %q, want %q", s, "<invalid>")
 	}
 
 	if err := body.WriteAsJSON(func() {}); err == nil {


### PR DESCRIPTION
## Summary
- add tests for string, JSON, and XML read/write helpers
- verify bodies reset after reads and error on invalid data
- exercise concurrent access for buffered and unbuffered bodies

## Testing
- `go test ./pkg/maigo -count=1`
- `go test ./...`
- `go test -race ./pkg/maigo -run TestUnbufferedBodyConcurrency -count=1` *(fails: race detected)*

------
https://chatgpt.com/codex/tasks/task_e_68a9ff48ad74832281a6a15146d1cc09

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Tests
  - Adiciona suíte de testes abrangente para I/O de corpo (bufferizado e não bufferizado): string, JSON e XML; validação de dados inválidos; verificação de fechamento de leitores e testes de concorrência.

- Bug Fixes
  - Corrige condição de corrida em leituras não bufferizadas, garantindo leituras/reescritas seguras e fechamento correto de leitores.
  - Garante que escritas em corpos bufferizados substituam corretamente o conteúdo anterior.

- Chores
  - Atualiza versão e aplica ajustes de lint.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->