### PR TITLE
Improve context wrapper tests and benchmarks

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,9 @@
+## v1.2.6
+
+- ensure `Context.Set` safely ignores nil, avoids redundant assignments, and compares pointer identities to prevent panics with uncomparable contexts
+- document the context wrapper's nil-safe semantics and lack of concurrent-safety, clarifying `Unwrap`'s use of `context.Background`
+- expand tests and benchmarks for `Context` to cover nil handling, idempotent `Unwrap`, and uncomparable contexts
+
 ## v1.2.5
 
 - fix data race in UnbufferedBody by using write locks

--- a/pkg/maigo/context.go
+++ b/pkg/maigo/context.go
@@ -1,3 +1,9 @@
+// Package maigo contains core primitives for the MaiGo project.
+//
+// The Context type wraps a standard context.Context. It is intentionally
+// nil-safe: calling Set(nil) leaves the existing context unchanged and Unwrap
+// always yields a non-nil context. The type is not safe for concurrent use; the
+// caller must not invoke Set and Unwrap concurrently.
 package maigo
 
 import (
@@ -12,7 +18,10 @@ type Context struct {
 	ctx context.Context
 }
 
-// Set implements contracts.Context.
+// Set replaces the wrapped context.
+//
+// Passing nil is a no-op. Context is not safe for concurrent use; callers must
+// not invoke Set and Unwrap from multiple goroutines without synchronization.
 func (c *Context) Set(ctx context.Context) {
 	if c == nil || ctx == nil {
 		return
@@ -21,7 +30,10 @@ func (c *Context) Set(ctx context.Context) {
 	c.ctx = ctx
 }
 
-// Unwrap implements contracts.Context.
+// Unwrap returns the stored context or context.Background if the receiver or
+// its stored context is nil. Returning Background ensures callers always receive
+// a usable context; cancellation and deadlines are expected to be managed by
+// the caller.
 func (c *Context) Unwrap() context.Context {
 	if c == nil || c.ctx == nil {
 		return context.Background()

--- a/pkg/maigo/context.go
+++ b/pkg/maigo/context.go
@@ -8,6 +8,7 @@ package maigo
 
 import (
 	"context"
+	"reflect"
 
 	"github.com/jeanmolossi/maigo/pkg/maigo/contracts"
 )
@@ -27,8 +28,15 @@ func (c *Context) Set(ctx context.Context) {
 		return
 	}
 
-	if c.ctx == ctx {
-		return
+	if c.ctx != nil {
+		oldVal := reflect.ValueOf(c.ctx)
+		newVal := reflect.ValueOf(ctx)
+
+		if oldVal.IsValid() && newVal.IsValid() &&
+			oldVal.Kind() == reflect.Pointer && newVal.Kind() == reflect.Pointer &&
+			oldVal.Pointer() == newVal.Pointer() {
+			return
+		}
 	}
 
 	c.ctx = ctx

--- a/pkg/maigo/context.go
+++ b/pkg/maigo/context.go
@@ -14,13 +14,19 @@ type Context struct {
 
 // Set implements contracts.Context.
 func (c *Context) Set(ctx context.Context) {
-	if ctx != nil {
-		c.ctx = ctx
+	if c == nil || ctx == nil {
+		return
 	}
+
+	c.ctx = ctx
 }
 
 // Unwrap implements contracts.Context.
 func (c *Context) Unwrap() context.Context {
+	if c == nil || c.ctx == nil {
+		return context.Background()
+	}
+
 	return c.ctx
 }
 

--- a/pkg/maigo/context.go
+++ b/pkg/maigo/context.go
@@ -27,13 +27,18 @@ func (c *Context) Set(ctx context.Context) {
 		return
 	}
 
+	if c.ctx == ctx {
+		return
+	}
+
 	c.ctx = ctx
 }
 
 // Unwrap returns the stored context or context.Background if the receiver or
 // its stored context is nil. Returning Background ensures callers always receive
-// a usable context; cancellation and deadlines are expected to be managed by
-// the caller.
+// a usable context and repeated calls in this nil case yield the same instance,
+// providing idempotency. Cancellation and deadlines are expected to be managed
+// by the caller.
 func (c *Context) Unwrap() context.Context {
 	if c == nil || c.ctx == nil {
 		return context.Background()

--- a/pkg/maigo/context_test.go
+++ b/pkg/maigo/context_test.go
@@ -48,6 +48,36 @@ func TestContextSetReplacesContext(t *testing.T) {
 	}
 }
 
+type uncomparableCtx struct {
+	context.Context
+	v []int
+}
+
+func TestContextSetWithUncomparableContext(t *testing.T) {
+	t.Parallel()
+
+	var c Context
+
+	ctx1 := uncomparableCtx{Context: context.Background(), v: []int{1}}
+	c.Set(ctx1)
+
+	ctx2 := uncomparableCtx{Context: context.Background(), v: []int{2}}
+
+	func() {
+		defer func() {
+			if r := recover(); r != nil {
+				t.Fatalf("Set() panicked: %v", r)
+			}
+		}()
+		c.Set(ctx2)
+	}()
+
+	got := c.Unwrap().(uncomparableCtx)
+	if got.v[0] != 2 {
+		t.Fatalf("Unwrap() = %v, want %v", got.v, ctx2.v)
+	}
+}
+
 func TestContextUnwrapReturnsNonNil(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/maigo/context_test.go
+++ b/pkg/maigo/context_test.go
@@ -1,0 +1,51 @@
+package maigo
+
+import (
+	"context"
+	"testing"
+)
+
+func TestContextSetIgnoresNil(t *testing.T) {
+	t.Parallel()
+
+	c := newDefaultContext()
+	ctxBefore := c.Unwrap()
+
+	c.Set(nil)
+
+	if c.Unwrap() != ctxBefore {
+		t.Errorf("Set(nil) changed context: got %v, want %v", c.Unwrap(), ctxBefore)
+	}
+}
+
+func TestContextUnwrapReturnsNonNil(t *testing.T) {
+	t.Parallel()
+
+	var c Context
+
+	if c.Unwrap() == nil {
+		t.Error("Unwrap() returned nil")
+	}
+
+	var cp *Context
+	if cp.Unwrap() == nil {
+		t.Error("Unwrap() on nil receiver returned nil")
+	}
+}
+
+func BenchmarkContextSet(b *testing.B) {
+	c := newDefaultContext()
+	ctx := context.Background()
+
+	for i := 0; i < b.N; i++ {
+		c.Set(ctx)
+	}
+}
+
+func BenchmarkContextUnwrap(b *testing.B) {
+	c := newDefaultContext()
+
+	for i := 0; i < b.N; i++ {
+		_ = c.Unwrap()
+	}
+}

--- a/pkg/maigo/context_test.go
+++ b/pkg/maigo/context_test.go
@@ -53,13 +53,34 @@ func TestContextUnwrapReturnsNonNil(t *testing.T) {
 
 	var c Context
 
-	if c.Unwrap() == nil {
-		t.Error("Unwrap() returned nil")
+	first := c.Unwrap()
+	if first == nil {
+		t.Fatal("Unwrap() returned nil")
+	}
+
+	second := c.Unwrap()
+	if second == nil {
+		t.Fatal("Unwrap() returned nil on second call")
+	}
+
+	if first != second {
+		t.Errorf("Unwrap() returned different instances: %p != %p", first, second)
 	}
 
 	var cp *Context
-	if cp.Unwrap() == nil {
-		t.Error("Unwrap() on nil receiver returned nil")
+
+	firstNil := cp.Unwrap()
+	if firstNil == nil {
+		t.Fatal("Unwrap() on nil receiver returned nil")
+	}
+
+	secondNil := cp.Unwrap()
+	if secondNil == nil {
+		t.Fatal("Unwrap() on nil receiver returned nil on second call")
+	}
+
+	if firstNil != secondNil {
+		t.Errorf("Unwrap() on nil receiver returned different instances: %p != %p", firstNil, secondNil)
 	}
 }
 

--- a/pkg/maigo/context_test.go
+++ b/pkg/maigo/context_test.go
@@ -11,10 +11,40 @@ func TestContextSetIgnoresNil(t *testing.T) {
 	c := newDefaultContext()
 	ctxBefore := c.Unwrap()
 
-	c.Set(nil)
+	c.Set(nil) //nolint:staticcheck // testing nil handling
 
 	if c.Unwrap() != ctxBefore {
 		t.Errorf("Set(nil) changed context: got %v, want %v", c.Unwrap(), ctxBefore)
+	}
+}
+
+func TestContextSetNilReceiver(t *testing.T) {
+	t.Parallel()
+
+	var c *Context
+
+	func() {
+		defer func() {
+			if r := recover(); r != nil {
+				t.Fatalf("Set() panicked: %v", r)
+			}
+		}()
+		c.Set(context.Background())
+	}()
+}
+
+type ctxKey struct{}
+
+func TestContextSetReplacesContext(t *testing.T) {
+	t.Parallel()
+
+	c := newDefaultContext()
+	ctx := context.WithValue(context.Background(), ctxKey{}, "v")
+
+	c.Set(ctx)
+
+	if got := c.Unwrap(); got != ctx {
+		t.Fatalf("Unwrap() = %v, want %v", got, ctx)
 	}
 }
 
@@ -37,6 +67,9 @@ func BenchmarkContextSet(b *testing.B) {
 	c := newDefaultContext()
 	ctx := context.Background()
 
+	b.ReportAllocs()
+	b.ResetTimer()
+
 	for i := 0; i < b.N; i++ {
 		c.Set(ctx)
 	}
@@ -44,6 +77,9 @@ func BenchmarkContextSet(b *testing.B) {
 
 func BenchmarkContextUnwrap(b *testing.B) {
 	c := newDefaultContext()
+
+	b.ReportAllocs()
+	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {
 		_ = c.Unwrap()


### PR DESCRIPTION
## Summary
- prevent `Context.Set` from assigning nil and allow nil receiver
- ensure `Context.Unwrap` always returns a valid context
- add unit tests and benchmarks for context wrapper

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68aa98ec5f58832290349a8eac228e0c

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Correções de Bugs**
  - Proteção contra chamadas em objetos nulos ao definir e recuperar o contexto, evitando panics.
  - Unwrap passa a retornar um contexto padrão (background) quando não há contexto inicializado, assegurando comportamento estável.
  - Set é idempotente e ignora valores nulos, evitando substituições indevidas.

- **Testes**
  - Inclusão de testes unitários cobrindo receivers nulos, entradas nulas e substituição de contexto.
  - Adição de benchmarks para Set e Unwrap.

- **Documentação**
  - Esclarecimento sobre não ser seguro para uso concorrente; chamadas Set/Unwrap não devem ocorrer simultaneamente.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->