### PR TITLE
feat: harden header handling with validation and concurrency

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	go.opentelemetry.io/otel/sdk v1.37.0
 	go.opentelemetry.io/otel/sdk/metric v1.37.0
 	go.opentelemetry.io/otel/trace v1.37.0
+	golang.org/x/net v0.43.0
 )
 
 require (
@@ -22,6 +23,7 @@ require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
 	go.opentelemetry.io/otel/metric v1.37.0 // indirect
-	golang.org/x/sys v0.33.0 // indirect
+	golang.org/x/sys v0.35.0 // indirect
+	golang.org/x/text v0.28.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -41,8 +41,12 @@ go.opentelemetry.io/otel/trace v1.37.0 h1:HLdcFNbRQBE2imdSEgm/kwqmQj1Or1l/7bW6mx
 go.opentelemetry.io/otel/trace v1.37.0/go.mod h1:TlgrlQ+PtQO5XFerSPUYG0JSgGyryXewPGyayAWSBS0=
 go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=
 go.uber.org/goleak v1.3.0/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=
-golang.org/x/sys v0.33.0 h1:q3i8TbbEz+JRD9ywIRlyRAQbM0qF7hu24q3teo2hbuw=
-golang.org/x/sys v0.33.0/go.mod h1:BJP2sWEmIv4KK5OTEluFJCKSidICx8ciO85XgH3Ak8k=
+golang.org/x/net v0.43.0 h1:lat02VYK2j4aLzMzecihNvTlJNQUq316m2Mr9rnM6YE=
+golang.org/x/net v0.43.0/go.mod h1:vhO1fvI4dGsIjh73sWfUVjj3N7CA9WkKJNQm2svM6Jg=
+golang.org/x/sys v0.35.0 h1:vz1N37gP5bs89s7He8XuIYXpyY0+QlsKmzipCbUtyxI=
+golang.org/x/sys v0.35.0/go.mod h1:BJP2sWEmIv4KK5OTEluFJCKSidICx8ciO85XgH3Ak8k=
+golang.org/x/text v0.28.0 h1:rhazDwis8INMIwQ4tpjLDzUhx6RlXqZNPEM0huQojng=
+golang.org/x/text v0.28.0/go.mod h1:U8nCwOR8jO/marOQ0QbDiOngZVEBB7MAiitBuMjXiNU=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=

--- a/pkg/maigo/contracts/headers.go
+++ b/pkg/maigo/contracts/headers.go
@@ -6,33 +6,17 @@ import (
 	"github.com/jeanmolossi/maigo/pkg/maigo/header"
 )
 
-// Header is the interface that wraps the basic methods for managing HTTP headers.
-//
-// This wrapper provides an abstraction layer over the standard http.Header type,
-// allowing for type-safe header manipulation and potential future enhancements
-// without changing the public API.
-//
-// It enables the package to implement custom header handling logic, such as
-// case-insensitive header matching or header-specific validations, while
-// maintaining a consistent interface.
-//
-// Example:
-//
-//	type CustomHeader struct {
-//	    header http.Header
-//	}
-//
-//	func (c *CustomHeader) Set(key header.Type, value string) {
-//	    c.header.Set(string(key), value)
-//	    // Add your logic here...
-//	}
+// Header defines a minimal, concurrency-safe API for manipulating HTTP
+// headers. Implementations should validate field names and values according
+// to RFC 7230 and may silently discard invalid input.
 type Header interface {
-	// Unwrap returns the underlying header map.
+	// Unwrap returns a copy of the header map for read-only inspection.
 	Unwrap() *http.Header
-	// Get retrieves the first value associated with the key.
+	// Get retrieves the first value associated with key, or an empty string
+	// if the key is absent.
 	Get(key header.Type) string
-	// Add appends a value for the key.
+	// Add appends value to key, preserving existing values.
 	Add(key header.Type, value string)
-	// Set sets the header value, replacing any existing values.
+	// Set replaces any existing values of key with value.
 	Set(key header.Type, value string)
 }

--- a/pkg/maigo/header.go
+++ b/pkg/maigo/header.go
@@ -2,40 +2,116 @@ package maigo
 
 import (
 	"net/http"
+	"sync"
 
 	"github.com/jeanmolossi/maigo/pkg/maigo/contracts"
 	"github.com/jeanmolossi/maigo/pkg/maigo/header"
+	"golang.org/x/net/http/httpguts"
 )
 
 var _ contracts.Header = (*Header)(nil)
 
+// Header wraps an http.Header map providing concurrency-safe access
+// and validation of header names and values according to RFC 7230.
+//
+// A nil Header is treated as an empty map; methods are no-ops when the
+// receiver is nil.
 type Header struct {
-	header *http.Header
+	mu     sync.RWMutex
+	header http.Header
 }
 
-// Add implements contracts.Header.
+// Add appends value to the field named by key. It creates the map on
+// first use and silently discards invalid names or values.
 func (h *Header) Add(key header.Type, value string) {
+	if h == nil {
+		return
+	}
+
+	if !httpguts.ValidHeaderFieldName(key.String()) || !httpguts.ValidHeaderFieldValue(value) {
+		return
+	}
+
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	if h.header == nil {
+		h.header = make(http.Header)
+	}
+
 	h.header.Add(key.String(), value)
 }
 
-// Get implements contracts.Header.
+// Get retrieves the first value associated with key. It returns an
+// empty string if the receiver is nil, the map is uninitialized or the
+// key is invalid or absent.
 func (h *Header) Get(key header.Type) string {
+	if h == nil || h.header == nil {
+		return ""
+	}
+
+	if !httpguts.ValidHeaderFieldName(key.String()) {
+		return ""
+	}
+
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+
 	return h.header.Get(key.String())
 }
 
-// Set implements contracts.Header.
+// Set replaces the current value of key with value. It initializes the
+// map on first use and silently ignores invalid names or values.
 func (h *Header) Set(key header.Type, value string) {
+	if h == nil {
+		return
+	}
+
+	if !httpguts.ValidHeaderFieldName(key.String()) || !httpguts.ValidHeaderFieldValue(value) {
+		return
+	}
+
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	if h.header == nil {
+		h.header = make(http.Header)
+	}
+
 	h.header.Set(key.String(), value)
 }
 
-// Unwrap implements contracts.Header.
+// Unwrap returns a copy of the underlying header map. The caller may
+// mutate the returned map without affecting the original, enabling safe
+// inspection outside of the mutex.
 func (h *Header) Unwrap() *http.Header {
-	return h.header
+	if h == nil {
+		hdr := make(http.Header)
+		return &hdr
+	}
+
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+
+	if h.header == nil {
+		hdr := make(http.Header)
+		return &hdr
+	}
+
+	copyHdr := make(http.Header, len(h.header))
+
+	for k, v := range h.header {
+		vv := make([]string, len(v))
+		copy(vv, v)
+		copyHdr[k] = vv
+	}
+
+	return &copyHdr
 }
 
-// newDefaultHTTPHeader initialized a new HTTPHeader.
+// newDefaultHTTPHeader initializes a new Header with an empty map.
 func newDefaultHTTPHeader() *Header {
 	return &Header{
-		header: &http.Header{},
+		header: make(http.Header),
 	}
 }

--- a/pkg/maigo/header_test.go
+++ b/pkg/maigo/header_test.go
@@ -1,0 +1,157 @@
+package maigo
+
+import (
+	"testing"
+
+	"github.com/jeanmolossi/maigo/pkg/maigo/header"
+)
+
+func TestHeader_AddAndGet(t *testing.T) {
+	t.Parallel()
+
+	h := newDefaultHTTPHeader()
+
+	h.Add(header.ContentType, "application/json")
+	h.Add(header.ContentType, "text/html")
+
+	if got := h.Get(header.ContentType); got != "application/json" {
+		t.Errorf("Get() = %q, want %q", got, "application/json")
+	}
+
+	values := h.Unwrap().Values(header.ContentType.String())
+	if len(values) != 2 {
+		t.Fatalf("values length = %d, want 2", len(values))
+	}
+
+	if values[0] != "application/json" || values[1] != "text/html" {
+		t.Errorf("values = %#v, want [application/json text/html]", values)
+	}
+}
+
+func TestHeader_Set(t *testing.T) {
+	t.Parallel()
+
+	h := newDefaultHTTPHeader()
+
+	h.Add(header.ContentType, "application/json")
+	h.Set(header.ContentType, "text/plain")
+
+	if got := h.Get(header.ContentType); got != "text/plain" {
+		t.Errorf("Get() after Set = %q, want %q", got, "text/plain")
+	}
+
+	values := h.Unwrap().Values(header.ContentType.String())
+	if len(values) != 1 || values[0] != "text/plain" {
+		t.Errorf("values = %#v, want [text/plain]", values)
+	}
+}
+
+func TestHeader_Get_NotFound(t *testing.T) {
+	t.Parallel()
+
+	h := newDefaultHTTPHeader()
+
+	if got := h.Get(header.ContentType); got != "" {
+		t.Errorf("Get() = %q, want empty", got)
+	}
+}
+
+func TestHeader_UnwrapReturnsCopy(t *testing.T) {
+	t.Parallel()
+
+	h := newDefaultHTTPHeader()
+	h.Set(header.ContentType, "application/json")
+
+	unwrapped := h.Unwrap()
+	if unwrapped == nil {
+		t.Fatal("Unwrap() returned nil")
+	}
+
+	if got := unwrapped.Get(header.ContentType.String()); got != "application/json" {
+		t.Fatalf("unwrapped header value = %q, want %q", got, "application/json")
+	}
+
+	unwrapped.Set(header.ContentType.String(), "text/plain")
+
+	if got := h.Get(header.ContentType); got != "application/json" {
+		t.Errorf("original header modified after Unwrap(), got %q", got)
+	}
+}
+
+func TestHeader_NilReceiver(t *testing.T) {
+	t.Parallel()
+
+	var h *Header
+
+	h.Add(header.ContentType, "application/json")
+	h.Set(header.ContentType, "text/plain")
+
+	if got := h.Get(header.ContentType); got != "" {
+		t.Errorf("Get() on nil receiver = %q, want empty", got)
+	}
+}
+
+func TestHeader_InvalidInputIgnored(t *testing.T) {
+	t.Parallel()
+
+	h := newDefaultHTTPHeader()
+	badName := header.Parse("Bad\nName")
+	h.Set(badName, "value")
+
+	if v := h.Get(badName); v != "" {
+		t.Fatalf("expected no value for invalid name, got %q", v)
+	}
+
+	h.Set(header.ContentType, "text/plain\r\nmalicious")
+
+	if v := h.Get(header.ContentType); v != "" {
+		t.Fatalf("expected no value for invalid value, got %q", v)
+	}
+}
+
+func BenchmarkHeaderAdd(b *testing.B) {
+	b.ReportAllocs()
+
+	for i := 0; i < b.N; i++ {
+		h := newDefaultHTTPHeader()
+		h.Add(header.ContentType, "application/json")
+	}
+}
+
+func BenchmarkHeaderSet(b *testing.B) {
+	b.ReportAllocs()
+
+	for i := 0; i < b.N; i++ {
+		h := newDefaultHTTPHeader()
+		h.Set(header.ContentType, "application/json")
+	}
+}
+
+func BenchmarkHeaderGet(b *testing.B) {
+	b.ReportAllocs()
+
+	h := newDefaultHTTPHeader()
+	h.Set(header.ContentType, "application/json")
+
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		if h.Get(header.ContentType) == "" {
+			b.Fatal("unexpected empty value")
+		}
+	}
+}
+
+func BenchmarkHeaderUnwrap(b *testing.B) {
+	b.ReportAllocs()
+
+	h := newDefaultHTTPHeader()
+
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		if h.Unwrap() == nil {
+			b.Fatal("unwrap returned nil")
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- make Header nil-safe and concurrency-safe
- validate header names and values per RFCs
- return defensive copy from Unwrap and expand tests
- document Header struct, methods, and interface for clarity

## Testing
- `/root/.local/share/mise/installs/go/1.24.3/bin/go test ./...`
- `/root/.local/share/mise/installs/go/1.24.3/bin/go test -bench . ./pkg/maigo`
- `golangci-lint run`


------
https://chatgpt.com/codex/tasks/task_e_68af9fa1af5c83229a6058441e32e044