### PR TITLE
test: add coverage for client builder and config

### DIFF
--- a/pkg/maigo/client_config_test.go
+++ b/pkg/maigo/client_config_test.go
@@ -1,0 +1,155 @@
+package maigo
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/jeanmolossi/maigo/pkg/maigo/contracts"
+	"github.com/jeanmolossi/maigo/pkg/maigo/method"
+)
+
+func TestClientConfigBase_HTTPMethods(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		call func(*ClientConfigBase, string) contracts.RequestBuilder
+		want method.Type
+	}{
+		{"GET", (*ClientConfigBase).GET, method.GET},
+		{"POST", (*ClientConfigBase).POST, method.POST},
+		{"PUT", (*ClientConfigBase).PUT, method.PUT},
+		{"DELETE", (*ClientConfigBase).DELETE, method.DELETE},
+		{"PATCH", (*ClientConfigBase).PATCH, method.PATCH},
+		{"HEAD", (*ClientConfigBase).HEAD, method.HEAD},
+		{"CONNECT", (*ClientConfigBase).CONNECT, method.CONNECT},
+		{"OPTIONS", (*ClientConfigBase).OPTIONS, method.OPTIONS},
+		{"TRACE", (*ClientConfigBase).TRACE, method.TRACE},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			c := newClientConfigBase("https://example.com")
+
+			rb := tt.call(c, "/path").(*RequestBuilder)
+
+			if rb.request.config.Method() != tt.want {
+				t.Errorf("Method() = %s, want %s", rb.request.config.Method(), tt.want)
+			}
+
+			if rb.request.config.Path() != "/path" {
+				t.Errorf("Path() = %s, want /path", rb.request.config.Path())
+			}
+		})
+	}
+}
+
+func TestNewClientConfigBase_Validations(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		baseURL string
+		wantErr error
+	}{
+		{"valid", "https://example.com", nil},
+		{"empty", "", ErrEmptyBaseURL},
+		{"invalid", "http://example.com:invalid", ErrParseURL},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			c := newClientConfigBase(tt.baseURL)
+
+			if tt.wantErr == nil {
+				if !c.Validations().IsEmpty() {
+					t.Fatalf("unexpected validation errors: %v", c.Validations().Unwrap())
+				}
+
+				return
+			}
+
+			if c.Validations().IsEmpty() {
+				t.Fatalf("expected validation error, got none")
+			}
+
+			if err := c.Validations().Get(0); !errors.Is(err, tt.wantErr) {
+				t.Errorf("validation error = %v, want %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestNewBalancedClientConfigBase_Validations(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		baseURLs []string
+		wantErrs []error
+	}{
+		{
+			name:     "empty slice",
+			baseURLs: nil,
+			wantErrs: []error{ErrEmptyBaseURL},
+		},
+		{
+			name:     "with invalid and empty",
+			baseURLs: []string{"", "http://example.com:invalid"},
+			wantErrs: []error{ErrEmptyBaseURL, ErrParseURL},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			c := newBalancedClientConfigBase(tt.baseURLs)
+
+			if c.Validations().Count() != len(tt.wantErrs) {
+				t.Fatalf("expected %d validations, got %d", len(tt.wantErrs), c.Validations().Count())
+			}
+
+			for _, we := range tt.wantErrs {
+				found := false
+
+				for i := 0; i < c.Validations().Count(); i++ {
+					if errors.Is(c.Validations().Get(i), we) {
+						found = true
+						break
+					}
+				}
+
+				if !found {
+					t.Errorf("expected error %v not found", we)
+				}
+			}
+		})
+	}
+}
+
+func TestNewBalancedClientConfigBase_RoundRobin(t *testing.T) {
+	t.Parallel()
+
+	baseURLs := []string{
+		"https://server1.com",
+		"https://server2.com",
+		"https://server3.com",
+	}
+
+	c := newBalancedClientConfigBase(baseURLs)
+
+	for i := 0; i < len(baseURLs)*2; i++ {
+		want := baseURLs[i%len(baseURLs)]
+		if got := c.BaseURL().String(); got != want {
+			t.Errorf("call %d: BaseURL() = %q, want %q", i, got, want)
+		}
+	}
+}

--- a/pkg/maigo/client_test.go
+++ b/pkg/maigo/client_test.go
@@ -1,6 +1,7 @@
 package maigo
 
 import (
+	"errors"
 	"testing"
 )
 
@@ -26,6 +27,73 @@ func TestNewClient(t *testing.T) {
 			clientBuilder := NewClient(tt.baseURL)
 			if !clientBuilder.client.Validations().IsEmpty() != tt.expectError {
 				t.Errorf("NewClient() error = %v, expectedError %v", clientBuilder.client.Validations().Count() > 0, tt.expectError)
+			}
+		})
+	}
+}
+
+func TestNewClientLoadBalancer(t *testing.T) {
+	t.Parallel()
+
+	baseURLs := []string{
+		"https://server1.com",
+		"https://server2.com",
+		"https://server3.com",
+	}
+
+	builder := NewClientLoadBalancer(baseURLs)
+
+	for i := 0; i < len(baseURLs)*2; i++ {
+		want := baseURLs[i%len(baseURLs)]
+		if got := builder.client.BaseURL().String(); got != want {
+			t.Errorf("call %d: BaseURL() = %q, want %q", i, got, want)
+		}
+	}
+}
+
+func TestNewClientLoadBalancer_InvalidBaseURLs(t *testing.T) {
+	t.Parallel()
+
+	builder := NewClientLoadBalancer([]string{
+		"",
+		"http://example.com:invalid",
+	})
+
+	if builder.client.Validations().Count() != 2 {
+		t.Fatalf("expected 2 validations, got %d", builder.client.Validations().Count())
+	}
+
+	if err := builder.client.Validations().Get(0); !errors.Is(err, ErrEmptyBaseURL) {
+		t.Errorf("first validation = %v, want ErrEmptyBaseURL", err)
+	}
+
+	if err := builder.client.Validations().Get(1); !errors.Is(err, ErrParseURL) {
+		t.Errorf("second validation = %v, want ErrParseURL", err)
+	}
+}
+
+func TestDefaultClient(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		baseURL string
+		wantErr bool
+	}{
+		{name: "valid", baseURL: "https://example.com", wantErr: false},
+		{name: "empty", baseURL: "", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			c := DefaultClient(tt.baseURL).(*ClientConfigBase)
+			gotErr := !c.Validations().IsEmpty()
+
+			if gotErr != tt.wantErr {
+				t.Errorf("Validations().IsEmpty() = %v, wantErr %v", gotErr, tt.wantErr)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary
- add tests for client load balancer, default client, and HTTP method helpers
- validate invalid base URLs and round-robin behavior

## Testing
- `golangci-lint run`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68afd68cc7d083229eb106510e9cb443